### PR TITLE
xpl: Add function to copy payload file to its destination

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,6 +38,9 @@ jobs:
           target: build-stage
           push: true
 
+      - name: Run xpload pytests
+        run: docker run --rm --network=host -e XPLOAD_CONFIG=dev ghcr.io/bnlnpps/xpload-build pytest xpload/tools/
+
       - name: Run CLI Tests
         run: docker run --rm --network=host -e XPLOAD_CONFIG=dev -v /tmp:/tmp ghcr.io/bnlnpps/xpload-build xpload/test/test_cli.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,12 @@ RUN cmake -S xpload -B build \
  && cmake --build build \
  && cmake --install build
 
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN python3 -m venv $VIRTUAL_ENV \
+ && . $VIRTUAL_ENV/bin/activate \
+ && pip install -r xpload/tools/requirements.txt
+
 
 FROM rockylinux:8.5 AS run-stage
 

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,5 +5,6 @@ idna==3.3
 jsonschema==4.2.1
 pathlib==1.0.1
 pyrsistent==0.18.0
+pytest==7.1.1
 requests==2.26.0
 urllib3==1.26.7

--- a/tools/test_xpload.py
+++ b/tools/test_xpload.py
@@ -1,0 +1,44 @@
+import hashlib
+import pathlib
+import pytest
+import shutil
+import xpload
+
+
+@pytest.fixture
+def payload_copy_params(request):
+    payload_file = pathlib.Path('/tmp/file.data')
+    prefixes = [pathlib.Path('/tmp/data0'), pathlib.Path('/tmp/data1')]
+    modes = request.param[:2]
+    domain = 'some_domain'
+
+    payload_file.write_bytes(b'012345')
+    for prefix, mode in zip(prefixes, modes):
+        prefix.mkdir()
+        prefix.chmod(mode) # Set access bits, e.g. rwxrwxrwx = 0o777
+
+    yield (payload_file, prefixes, domain)
+
+    # Clean up
+    payload_file.unlink()
+    for prefix in prefixes:
+        shutil.rmtree(prefix, ignore_errors=True)
+
+
+@pytest.mark.parametrize('payload_copy_params', [[0o700, 0o700], [0o400, 0o700], [0o700, 0o400]], indirect=True)
+def test_payload_copy(payload_copy_params):
+    (src, prefixes, domain) = payload_copy_params
+
+    dst = xpload.payload_copy(src, prefixes, domain)
+    md5sum = hashlib.md5(dst.open('rb').read()).hexdigest()
+
+    assert dst.exists() and \
+           (dst == prefixes[0]/domain/f'{md5sum}_{src.name}' or dst == prefixes[1]/domain/f'{md5sum}_{src.name}')
+
+
+@pytest.mark.parametrize('payload_copy_params', [[0o400, 0o400]], indirect=True)
+def test_payload_copy_fail(payload_copy_params):
+    (src, prefixes, domain) = payload_copy_params
+
+    with pytest.raises(Exception) as e_info:
+        dst = xpload.payload_copy(src, prefixes, domain)


### PR DESCRIPTION
The `payload_copy(payload_file, prefixes, domain)` function copies a local `payload_file` to the first valid `prefix` from a list of `prefixes`. As a test, we can create a fake payload file and try to copy it into some directory `/tmp/data_dir`:

```shell
$ dd if=/dev/random of=/tmp/payload.data bs=1k count=1
$ md5sum /tmp/payload.data
d5a5e2d2bb86a3eeed796ed823137144  /tmp/payload.data
$ mkdir -p /tmp/data_dir
```

In the above example calling the function as

```python
payload_copy('/tmp/payload.data', ['/tmp/nonexisting_dir', '/tmp/data_dir'], 'some_domain')
```
should copy the file to `/tmp/data_dir/some_domain/d5a5e2d2bb86a3eeed796ed823137144_payload.data` 