### PR TITLE
Explicitly link standard c++ library (filesystem)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_executable(test_xpload test_xpload.cpp)
-target_link_libraries(test_xpload xpload CURL::libcurl)
+target_link_libraries(test_xpload xpload CURL::libcurl stdc++fs)
 target_include_directories(test_xpload PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 add_executable(test_xpload_rand test_xpload_rand.cpp)
-target_link_libraries(test_xpload_rand xpload CURL::libcurl)
+target_link_libraries(test_xpload_rand xpload CURL::libcurl stdc++fs)
 target_include_directories(test_xpload_rand PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 add_test(NAME "test_xpload_1" COMMAND bash -c "./test_xpload -t tag_1")


### PR DESCRIPTION
Appears to be required by gcc 8.3

Resolves #25 