### PR TITLE
README: Fix option name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ fetch multiple payloads for various subsystems associated with it.
 
 ```shell
 xpl add tag tag1 --type tag1_type --status tag1_status --domains domain1 domain2
-xpl add pil tag1 domain1 /tmp/payload1.data --treq 11 --end 33
-xpl add pil tag1 domain2 /tmp/payload2.data --treq 22 --end 33
+xpl add pil tag1 domain1 /tmp/payload1.data --start 11 --end 33
+xpl add pil tag1 domain2 /tmp/payload2.data --start 22 --end 33
 xpl push
 ```
 


### PR DESCRIPTION
Fixes #42

Indeed, when adding intervals with `plx add` we use `--start` and `--end` options (or short `-s` and `-e` options respectively).
While fetching with `plx fetch` we use `--treq` or `-t` option to pass a (requested) time

[skip ci]